### PR TITLE
Ignore exceptions handled by Django.

### DIFF
--- a/django_dd_logger/middleware/error_log.py
+++ b/django_dd_logger/middleware/error_log.py
@@ -1,5 +1,8 @@
 import logging
 
+from django.core.exceptions import BadRequest, PermissionDenied, SuspiciousOperation
+from django.http import Http404
+from django.http.multipartparser import MultiPartParserError
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +15,11 @@ class ErrorLoggingMiddleware:
         return self.get_response(request)
 
     def process_exception(self, request, exception):
+        if isinstance(
+            exception,
+            (PermissionDenied, Http404, MultiPartParserError, BadRequest, SuspiciousOperation),
+        ):
+            return
         logger.exception(exception)
 
     def process_response(self, request, response):


### PR DESCRIPTION
Those exceptions are handled explicitly by Django. They should not be logged.